### PR TITLE
2949: ensure we publish during the release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,6 @@ publishing {
     publications {
       mavenJava(MavenPublication) {
         from components.java
-
           artifact sourceJar {
             classifier "sources"
           }
@@ -88,4 +87,5 @@ configurations.all {
     ]
   }
 }
-    
+
+afterReleaseBuild.dependsOn publish


### PR DESCRIPTION
During the release process we want to make sure that the build artefacts for this version are pushed to a maven server.
