### PR TITLE
2869: create injector in PRODUCTION mode

### DIFF
--- a/src/main/java/uk/gov/verify/guice/GuiceBundle.java
+++ b/src/main/java/uk/gov/verify/guice/GuiceBundle.java
@@ -3,6 +3,7 @@ package uk.gov.verify.guice;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Module;
+import com.google.inject.Stage;
 import com.hubspot.dropwizard.guice.JerseyModule;
 import com.hubspot.dropwizard.guice.JerseyUtil;
 import io.dropwizard.Configuration;
@@ -33,7 +34,7 @@ public class GuiceBundle<T extends Configuration> implements ConfiguredBundle<T>
 
     @Override
     public void run(T configuration, Environment environment) {
-        injector = Guice.createInjector(getModules(configuration, environment));
+        injector = Guice.createInjector(Stage.PRODUCTION, getModules(configuration, environment));
         JerseyUtil.registerGuiceBound(injector, environment.jersey());
         JerseyUtil.registerGuiceFilter(environment);
     }

--- a/src/test/java/uk/gov/verify/guice/GuiceBundleTest.java
+++ b/src/test/java/uk/gov/verify/guice/GuiceBundleTest.java
@@ -7,10 +7,12 @@ import com.squarespace.jersey2.guice.BootstrapUtils;
 import io.dropwizard.Application;
 import io.dropwizard.Configuration;
 import io.dropwizard.client.JerseyClientBuilder;
+import io.dropwizard.client.JerseyClientConfiguration;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import io.dropwizard.testing.ResourceHelpers;
 import io.dropwizard.testing.junit.DropwizardAppRule;
+import io.dropwizard.util.Duration;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -89,7 +91,9 @@ public class GuiceBundleTest {
 
     @Test
     public void shouldReturnTheValueBoundUsingTheGuiceInjector() throws Exception {
-        Client client = new JerseyClientBuilder(APP_RULE.getEnvironment()).build("client");
+        JerseyClientConfiguration configuration = new JerseyClientConfiguration();
+        configuration.setTimeout(Duration.seconds(5));
+        Client client = new JerseyClientBuilder(APP_RULE.getEnvironment()).using(configuration).build("client");
         String receivedValue = client.target("http://localhost:" + APP_RULE.getLocalPort() + "/injector").request().get(String.class);
         assertThat(receivedValue).isEqualTo(SOME_VALUE);
     }


### PR DESCRIPTION
Calling the injector without the stage argument unfortunately causes it to build the injector in development mode. This is the opposite of what we want. Therefore, I have added the Stage.PRODUCTION argument.
