### PR TITLE
bau: update for dropwizard 0.8.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ idea {
 }
 
 def dependencyVersions = [
-  dropwizard:'0.8.3'
+  dropwizard:'0.8.4'
 ]
 
 group = "uk.gov.verify"


### PR DESCRIPTION
Also uses the 0.8.4.0 version of dropwizard-guice.
